### PR TITLE
Pin pyrsistent to the mayor version to this specific one

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-pyrsistent==0.11.13
+pyrsistent~=0.11.13
 singledispatch


### PR DESCRIPTION
## Context

When using pyredux with pipenv I can't install the latest version of pyrsistent because pyredux requires this exact version.

## Solution

This changes that to accept any version that is bigger or equal to the mentioned version but the same major release.